### PR TITLE
Window restoration secondary monitors #86

### DIFF
--- a/src/Demo/Program/MauiProgram.cs
+++ b/src/Demo/Program/MauiProgram.cs
@@ -9,6 +9,7 @@ using DigitalProduction.Demo.ViewModels;
 using DigitalProduction.Maui;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.LifecycleEvents;
+using DigitalProduction.Maui.UI;
 
 namespace DigitalProduction.Demo;
 
@@ -28,19 +29,14 @@ public static class MauiProgram
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
 				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
 			});
-		DigitalProduction.Maui.UI.LifecycleEventsInstaller.ConfigureLifecycleEvents(builder);
-		#if WINDOWS
-			builder.ConfigureLifecycleEvents(events =>  
-			{
-				events.AddWindows(windowsLifecycleBuilder =>  
-				{  
-					windowsLifecycleBuilder.OnWindowCreated(window =>  
-					{  
-						window.Title = "Maui AppToolkit";
-					});  
-				});  
-			});
-		#endif
+
+		LifecycleOptions lifecycleOptions = new()
+		{
+			EnsureOnScreen			= true,
+			DisableMaximizeButton	= false,
+			WindowTitle				= "Maui AppToolkit"
+		};
+		DigitalProduction.Maui.UI.LifecycleEventsInstaller.ConfigureLifecycleEvents(builder, lifecycleOptions);
 
 		RegisterViewsAndViewModels(builder.Services);
 		RegisterEssentials(builder.Services);

--- a/src/Demo/Program/MauiProgram.cs
+++ b/src/Demo/Program/MauiProgram.cs
@@ -32,7 +32,7 @@ public static class MauiProgram
 
 		LifecycleOptions lifecycleOptions = new()
 		{
-			EnsureOnScreen			= true,
+			EnsureOnScreen			= false,
 			DisableMaximizeButton	= false,
 			WindowTitle				= "Maui AppToolkit"
 		};

--- a/src/Library/Application/LifecycleEventsInstaller.cs
+++ b/src/Library/Application/LifecycleEventsInstaller.cs
@@ -2,10 +2,10 @@
 
 public static partial class LifecycleEventsInstaller
 {
-	public static void ConfigureLifecycleEvents(MauiAppBuilder builder)
+	public static void ConfigureLifecycleEvents(MauiAppBuilder builder, LifecycleOptions? lifecycleOptions = null)
 	{
-		PlatformConfigureLifecycleEvents(builder);
+		PlatformConfigureLifecycleEvents(builder, lifecycleOptions);
 	}
 
-	static partial void PlatformConfigureLifecycleEvents(MauiAppBuilder builder, bool ensureOnScreen = true);
+	static partial void PlatformConfigureLifecycleEvents(MauiAppBuilder builder, LifecycleOptions? lifecycleOptions);
 }

--- a/src/Library/Application/LifecycleOptions.cs
+++ b/src/Library/Application/LifecycleOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace DigitalProduction.Maui.UI;
+
+public class LifecycleOptions
+{
+	public bool		EnsureOnScreen			{ get; set; }	= false;
+	public bool		DisableMaximizeButton	{ get; set; }	= false;
+	public string	WindowTitle				{ get; set; }	= string.Empty;
+}

--- a/src/Library/Platforms/Windows/Application/AppTools.cs
+++ b/src/Library/Platforms/Windows/Application/AppTools.cs
@@ -55,13 +55,9 @@ public static class AppTools
 		window.X = Preferences.Default.Get(name+".Position.X", window.X);
 		window.Y = Preferences.Default.Get(name+".Position.Y", window.Y);
 
-		if (ensureOnScreen && window.X < 0)
+		if (ensureOnScreen && (window.X < 0 || window.Y < 0))
 		{
 			window.X = 20;
-		}
-
-		if (ensureOnScreen && window.Y < 0)
-		{
 			window.Y = 20;
 		}
 

--- a/src/Library/Platforms/Windows/Application/AppTools.cs
+++ b/src/Library/Platforms/Windows/Application/AppTools.cs
@@ -50,19 +50,19 @@ public static class AppTools
 		Preferences.Default.Set(name+".Position.Height", window.Height);
 	}
 
-	public static void RestoreWindowPosition(Window window, string name, bool ensureOnScreen = true)
+	public static void RestoreWindowPosition(Window window, string name, bool ensureOnScreen)
 	{
 		window.X = Preferences.Default.Get(name+".Position.X", window.X);
 		window.Y = Preferences.Default.Get(name+".Position.Y", window.Y);
 
 		if (ensureOnScreen && window.X < 0)
 		{
-			window.X = 90;
+			window.X = 20;
 		}
 
 		if (ensureOnScreen && window.Y < 0)
 		{
-			window.Y = 40;
+			window.Y = 20;
 		}
 
 		window.Width	= Preferences.Default.Get(name+".Position.Width", window.Width);

--- a/src/Library/Platforms/Windows/Application/LifecycleEventsInstaller.cs
+++ b/src/Library/Platforms/Windows/Application/LifecycleEventsInstaller.cs
@@ -10,10 +10,7 @@ public static partial class LifecycleEventsInstaller
 	static partial void PlatformConfigureLifecycleEvents(MauiAppBuilder builder, LifecycleOptions? lifecycleOptions)
 	{
 		// If no options were provided, we default them.
-		if (lifecycleOptions == null)
-		{
-			lifecycleOptions = new LifecycleOptions();
-		}
+		lifecycleOptions ??= new LifecycleOptions();
 
 		builder.ConfigureLifecycleEvents(events =>
 		{

--- a/src/Library/Platforms/Windows/Application/LifecycleEventsInstaller.cs
+++ b/src/Library/Platforms/Windows/Application/LifecycleEventsInstaller.cs
@@ -1,13 +1,20 @@
 ﻿using Microsoft.Maui.LifecycleEvents;
 using Microsoft.Maui.Platform;
+using Microsoft.UI;
 using Microsoft.UI.Windowing;
 
 namespace DigitalProduction.Maui.UI;
 
 public static partial class LifecycleEventsInstaller
 {
-	static partial void PlatformConfigureLifecycleEvents(MauiAppBuilder builder, bool ensureOnScreen)
+	static partial void PlatformConfigureLifecycleEvents(MauiAppBuilder builder, LifecycleOptions? lifecycleOptions)
 	{
+		// If no options were provided, we default them.
+		if (lifecycleOptions == null)
+		{
+			lifecycleOptions = new LifecycleOptions();
+		}
+
 		builder.ConfigureLifecycleEvents(events =>
 		{
 			// We want to set the restored position, size, and state (restored/maximized) here before the window is created.
@@ -18,35 +25,63 @@ public static partial class LifecycleEventsInstaller
 			{
 				windowsLifecycleBuilder.OnWindowCreated(window =>
 				{
-					// Microsoft.UI.Xaml.Window window
+					// Microsoft.UI.Xaml.Window window.
 					window.ExtendsContentIntoTitleBar = false;
 
 					AppWindow? appWindow = DigitalProduction.Maui.UI.AppTools.GetAppWindow((MauiWinUIWindow)window);
 
-					switch (appWindow?.Presenter)
-					{
-						case Microsoft.UI.Windowing.OverlappedPresenter overLappedPresenter:
-							MauiWinUIWindow winUIWindow	= (MauiWinUIWindow)window;
-
-							if (winUIWindow.GetWindow() is Window mauiWindow)
-							{
-								// Set the restored position.
-								DigitalProduction.Maui.UI.AppTools.RestoreWindowPosition(mauiWindow, "MainWindow", ensureOnScreen);
-
-								OverlappedPresenterState state = DigitalProduction.Maui.UI.AppTools.GetWindowState("MainWindow");
-								if (state == OverlappedPresenterState.Maximized)
-								{
-									overLappedPresenter.Maximize();
-								}
-								else
-								{
-									overLappedPresenter.Restore();
-								}
-							}
-							break;
-					}
+					SetupPositionSavingAndRestoration(lifecycleOptions, window, appWindow);
+					SetWindowTitle(lifecycleOptions, window);
+					SetDisableMaximizedWindow(lifecycleOptions, appWindow);
 				});
 			});
 		});
+	}
+
+	private static void SetupPositionSavingAndRestoration(LifecycleOptions lifecycleOptions, Microsoft.UI.Xaml.Window window, AppWindow? appWindow)
+	{
+		switch (appWindow?.Presenter)
+		{
+			case Microsoft.UI.Windowing.OverlappedPresenter overLappedPresenter:
+				MauiWinUIWindow winUIWindow = (MauiWinUIWindow)window;
+
+				if (winUIWindow.GetWindow() is Window mauiWindow)
+				{
+					// Set the restored position.
+					DigitalProduction.Maui.UI.AppTools.RestoreWindowPosition(mauiWindow, "MainWindow", lifecycleOptions.EnsureOnScreen);
+
+					OverlappedPresenterState state = DigitalProduction.Maui.UI.AppTools.GetWindowState("MainWindow");
+					if (state == OverlappedPresenterState.Maximized)
+					{
+						overLappedPresenter.Maximize();
+					}
+					else
+					{
+						overLappedPresenter.Restore();
+					}
+				}
+				break;
+		}
+	}
+
+	private static void SetWindowTitle(LifecycleOptions lifecycleOptions, Microsoft.UI.Xaml.Window window)
+	{
+		if (lifecycleOptions.WindowTitle != string.Empty)
+		{
+			window.Title = lifecycleOptions.WindowTitle;
+		}
+	}
+
+	private static void SetDisableMaximizedWindow(LifecycleOptions lifecycleOptions, AppWindow? appWindow)
+	{
+		if (lifecycleOptions.DisableMaximizeButton)
+		{
+			switch (appWindow?.Presenter)
+			{
+				case OverlappedPresenter overlappedPresenter:
+					overlappedPresenter.IsMaximizable = false;
+					break;
+			}
+		}
 	}
 }

--- a/src/Library/Platforms/Windows/ContentPages/DigitalProductionMainPage.xaml.cs
+++ b/src/Library/Platforms/Windows/ContentPages/DigitalProductionMainPage.xaml.cs
@@ -25,7 +25,8 @@ public partial class DigitalProductionMainPage
 
 				// Add the event handler only after setting the initial position.  Otherwise, it will overwrite the
 				// saved values and we will not get restoration of the correct position.
-				parentWindow.SizeChanged += this.OnSizeChanged;
+				parentWindow.SizeChanged		+= OnSizeChanged;
+				parentWindow.PropertyChanged	+= OnPropertyChanged;
 				break;
 		}
 	}

--- a/src/Library/Platforms/Windows/ContentPages/DigitalProductionMainPage.xaml.cs
+++ b/src/Library/Platforms/Windows/ContentPages/DigitalProductionMainPage.xaml.cs
@@ -25,8 +25,7 @@ public partial class DigitalProductionMainPage
 
 				// Add the event handler only after setting the initial position.  Otherwise, it will overwrite the
 				// saved values and we will not get restoration of the correct position.
-				parentWindow.SizeChanged		+= OnSizeChanged;
-				parentWindow.PropertyChanged	+= OnPropertyChanged;
+				parentWindow.SizeChanged += this.OnSizeChanged;
 				break;
 		}
 	}
@@ -43,14 +42,11 @@ public partial class DigitalProductionMainPage
 
 	private void OnPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs eventArgs)
 	{
-		if (eventArgs.PropertyName == "X" || eventArgs.PropertyName == "Y")
+		if ((eventArgs.PropertyName == "X" || eventArgs.PropertyName == "Y") && IsRestoredPresenter())
 		{
-			if (IsRestoredPresenter())
-			{ 
-				// Only save the postion and size in the restored state.  Otherwise we are just save and restoring the maximized
-				// size which is not what we want.
-				DigitalProduction.Maui.UI.AppTools.SaveWindowPosition(GetParentWindow(), "MainWindow");
-			}
+			// Only save the postion and size in the restored state.  Otherwise we are just save and restoring the maximized
+			// size which is not what we want.
+			DigitalProduction.Maui.UI.AppTools.SaveWindowPosition(GetParentWindow(), "MainWindow");
 		}
 	}
 
@@ -61,8 +57,6 @@ public partial class DigitalProductionMainPage
 		switch (appWindow?.Presenter)
 		{
 			case OverlappedPresenter overLappedPresenter:
-				DigitalProduction.Maui.UI.AppTools.SaveWindowState(overLappedPresenter.State, "MainWindow");
-
 				if (overLappedPresenter.State == OverlappedPresenterState.Restored)
 				{
 					return true;
@@ -71,28 +65,6 @@ public partial class DigitalProductionMainPage
 		}
 
 		return false;
-	}
-
-	private void OnPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs eventArgs)
-	{
-		if (eventArgs.PropertyName == "X" || eventArgs.PropertyName == "Y")
-		{
-			AppWindow? appWindow = GetAppWindow();
-
-			switch (appWindow?.Presenter)
-			{
-				case OverlappedPresenter overLappedPresenter:
-					DigitalProduction.Maui.UI.AppTools.SaveWindowState(overLappedPresenter.State, "MainWindow");
-
-					if (overLappedPresenter.State == OverlappedPresenterState.Restored)
-					{
-						// Only save the postion and size in the restored state.  Otherwise we are just save and restoring the maximized
-						// size which is not what we want.
-						DigitalProduction.Maui.UI.AppTools.SaveWindowPosition(GetParentWindow(), "MainWindow");
-					}
-					break;
-			}
-		}
 	}
 
 	protected AppWindow? GetAppWindow()


### PR DESCRIPTION
Creates life cycle options to provide more universal control of how life cycle events are installed and handled.
Closes #86 